### PR TITLE
Add comments to `main.tf` and `cloudbuild-migrate.yaml` to reflect YouTube walkthrough

### DIFF
--- a/cloud-run-django-terraform/cloudbuild-migrate.yaml
+++ b/cloud-run-django-terraform/cloudbuild-migrate.yaml
@@ -1,5 +1,5 @@
-# Applies Database and Static Migrations
-
+# cloudbuild-migrate.yaml
+# Step 13: Run migrations and prepare static files
 steps:
   - name: "gcr.io/google-appengine/exec-wrapper"
     args:


### PR DESCRIPTION
`main.tf` does not currently reflect what's shown in the YouTube walkthrough that accompanies this repository. I've added the comments and line breaks from the video walkthrough so `main.tf` now accurately reflects what's shown in the video. Similarly with `cloudbuild-migrate.yaml`.